### PR TITLE
[Fix] Change coupon type to `discount`.

### DIFF
--- a/src/Cart/CartLineCoupon.php
+++ b/src/Cart/CartLineCoupon.php
@@ -8,7 +8,6 @@
 namespace Krokedil\WooCommerce\Cart;
 
 use Krokedil\WooCommerce\OrderLineData;
-use _PHPStan_503e82092\Nette\NotImplementedException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -272,7 +271,7 @@ class CartLineCoupon extends OrderLineData {
 	 * @return void
 	 */
 	public function set_type() {
-		$this->type = apply_filters( $this->get_filter_name( 'type' ), $this->coupon->get_discount_type(), $this->coupon );
+		$this->type = apply_filters( $this->get_filter_name( 'type' ), 'discount', $this->coupon );
 	}
 
 	/**

--- a/src/Order/OrderLineCoupon.php
+++ b/src/Order/OrderLineCoupon.php
@@ -15,6 +15,12 @@ defined( 'ABSPATH' ) || exit;
  * Order line coupon class.
  */
 class OrderLineCoupon extends OrderLineData {
+	/**
+	 * Filter prefix.
+	 *
+	 * @var string
+	 */
+	public $filter_prefix = 'order_line_coupon';
 
 	/**
 	 * WooCommerce order item coupon.
@@ -264,9 +270,7 @@ class OrderLineCoupon extends OrderLineData {
 	 * @return void
 	 */
 	public function set_type() {
-		$meta_data  = $this->coupon->get_meta( 'coupon_data', true );
-		$type       = isset( $meta_data['discount_type'] ) ? $meta_data['discount_type'] : 'fixed_cart';
-		$this->type = apply_filters( $this->get_filter_name( 'type' ), $type, $this->coupon );
+		$this->type = apply_filters( $this->get_filter_name( 'type' ), 'discount', $this->coupon );
 	}
 
 	/**


### PR DESCRIPTION
To send coupons to Klarna their type needs to be `discount`.

<img width="815" alt="Screenshot 2023-07-20 at 12 43 47 PM" src="https://github.com/krokedil/woocommerce/assets/12052390/2e5a8194-b930-4056-a74d-1988fb472370">


Also add filter prefix for `OrderLineCoupon` class.
