### PR TITLE
Skip shipping lines for free trials

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -75,7 +75,11 @@ class Cart extends OrderData {
 
 			// If the cart contain only free trial, we'll ignore the shipping methods. The shipping method will still be included in the subscription renewal.
 			if ( class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::all_cart_items_have_free_trial() ) {
-				return;
+
+				// When a renewal fails for free trial subscription, it will need payment. Only on the initial subscription is payment not needed, and we must therefore not charge for shipping.
+				if ( ! WC()->cart->needs_payment() ) {
+					return;
+				}
 			}
 
 			if ( empty( $chosen_shipping_methods ) ) {

--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -84,7 +84,15 @@ class Cart extends OrderData {
 
 			// Get the shipping rates for the package.
 			$shipping_rates = $package['rates'] ?? array();
-			foreach ( $shipping_ids as $shipping_id ) {
+			foreach ( $shipping_ids as $key => $shipping_id ) {
+				// Skip shipping lines for free trials.
+				if ( class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::cart_contains_subscription() ) {
+					$pattern = '/_after_a_\d+_\w+_trial/';
+					if ( preg_match( $pattern, $key ) ) {
+						continue;
+					}
+				}
+
 				if ( $shipping_rates[ $shipping_id ] ?? false ) {
 					$shipping_rate         = $shipping_rates[ $shipping_id ];
 					$shipping_line         = new CartLineShipping( $shipping_rate, $this->config );


### PR DESCRIPTION
If a cart contains a subscription trial, and it has a recurring shipping cost, we incorrectly add the shipping cost to the first purchase. This shipping package has a special naming that follows the pattern `_after_a_\d+_\w+_trial`.

Reference:
- `class-wc-subscriptions-cart.php → WC_Subscriptions_Cart::get_recurring_cart_key`.

# Current behavior

```
"order_tax_amount": 0,      ← shipping cost not included, as expected.
"order_lines": [{
	"name": "A Subscription (No start fee, Free trial)",
	"product_url": "https:\/\/krokedil.montazar.eu.ngrok.io\/product\/a-subscription-no-start-fee-free-trial\/",
	"quantity": 1,
	"quantity_unit": "pcs",
	"reference": 185,
	"tax_rate": 0,
	"total_amount": 0,
	"total_discount_amount": 0,
	"total_tax_amount": 0,
	"type": "physical",
	"unit_price": 0,
	"subscription": {
		"name": "A Subscription (No start fee, Free trial)",
		"interval": "MONTH",
		"interval_count": 1
	}
}, {
	"name": "Flat rate", ← shipping incorrectly included
	"quantity": 1,
	"quantity_unit": "pcs",
	"reference": "flat_rate:7",
	"tax_rate": 0,
	"total_amount": 4900, ← total amount not included in order_amount
	"total_discount_amount": 0,
	"total_tax_amount": 0,
	"type": "shipping_fee",
	"unit_price": 4900
}],
```

# Expected behavior

```
"order_tax_amount": 0
"order_lines": [{
	"name": "A Subscription (No start fee, Free trial)",
	"product_url": "https:\/\/krokedil.montazar.eu.ngrok.io\/product\/a-subscription-no-start-fee-free-trial\/",
	"quantity": 1,
	"quantity_unit": "pcs",
	"reference": 185,
	"tax_rate": 0,
	"total_amount": 0,
	"total_discount_amount": 0,
	"total_tax_amount": 0,
	"type": "physical",
	"unit_price": 0,
	"subscription": {
		"name": "A Subscription (No start fee, Free trial)",
		"interval": "MONTH",
		"interval_count": 1
	}
}],
```