### PR TITLE
Retrieve tax from Avatax

### DIFF
--- a/src/Cart/CartLineItem.php
+++ b/src/Cart/CartLineItem.php
@@ -69,6 +69,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product name
+	 *
 	 * @return void
 	 */
 	public function set_name() {
@@ -79,6 +80,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product sku
+	 *
 	 * @return void
 	 */
 	public function set_sku() {
@@ -96,6 +98,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product quantity
+	 *
 	 * @return void
 	 */
 	public function set_quantity() {
@@ -104,6 +107,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product unit price
+	 *
 	 * @return void
 	 */
 	public function set_unit_price() {
@@ -114,6 +118,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product subtotal unit price
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_unit_price() {
@@ -124,6 +129,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product tax rate
+	 *
 	 * @return void
 	 */
 	public function set_tax_rate() {
@@ -135,15 +141,15 @@ class CartLineItem extends OrderLineData {
 			if ( isset( $vat['rate'] ) ) {
 				$item_tax_rate = round( $vat['rate'] * 100 );
 			} else {
-				$item_tax_rate = 0;
+				$item_tax_rate = 0.0 === floatval( $this->cart_item['line_total'] ) ? 0 : round( $this->cart_item['line_tax'] / $this->cart_item['line_total'] * 10000 );
 			}
 		}
-
 		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $item_tax_rate, $this->cart_item );
 	}
 
 	/**
 	 * Function to set product total amount
+	 *
 	 * @return void
 	 */
 	public function set_total_amount() {
@@ -152,6 +158,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product subtotal amount
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_amount() {
@@ -160,6 +167,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product total discount amount
+	 *
 	 * @return void
 	 */
 	public function set_total_discount_amount() {
@@ -169,10 +177,11 @@ class CartLineItem extends OrderLineData {
 	}
 
 	/**
-     * Abstract function to set product total discount tax amount
-     * @return void
-     */
-    public function set_total_discount_tax_amount() {
+	 * Abstract function to set product total discount tax amount
+	 *
+	 * @return void
+	 */
+	public function set_total_discount_tax_amount() {
 		$total_discount_tax_amount = $this->cart_item['line_subtotal_tax'] - $this->cart_item['line_tax'];
 
 		$this->total_discount_tax_amount = apply_filters( $this->get_filter_name( 'total_discount_tax_amount' ), $this->format_price( $total_discount_tax_amount ), $this->cart_item );
@@ -180,6 +189,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product total tax amount
+	 *
 	 * @return void
 	 */
 	public function set_total_tax_amount() {
@@ -188,6 +198,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product subtotal tax amount
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_tax_amount() {
@@ -196,6 +207,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product type
+	 *
 	 * @return void
 	 */
 	public function set_type() {
@@ -204,6 +216,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product url
+	 *
 	 * @return void
 	 */
 	public function set_product_url() {
@@ -217,6 +230,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product image url
+	 *
 	 * @return void
 	 */
 	public function set_image_url() {
@@ -230,6 +244,7 @@ class CartLineItem extends OrderLineData {
 
 	/**
 	 * Function to set product compatability
+	 *
 	 * @return void
 	 */
 	public function set_compatability() {

--- a/src/Cart/CartLineShipping.php
+++ b/src/Cart/CartLineShipping.php
@@ -20,19 +20,19 @@ class CartLineShipping extends OrderLineData {
 	 */
 	public $filter_prefix = 'cart_line_shipping';
 
-    /**
-     * The WooCommerce shipping rate.
-     *
-     * @var \WC_Shipping_Rate $shipping_rate
-     */
-    public $shipping_rate;
+	/**
+	 * The WooCommerce shipping rate.
+	 *
+	 * @var \WC_Shipping_Rate $shipping_rate
+	 */
+	public $shipping_rate;
 
-    /**
-     * Constructor.
-     *
-     * @param \WC_Shipping_Rate $shipping_rate The WooCommerce shipping rate.
-     * @param array             $config        Configuration array.
-     */
+	/**
+	 * Constructor.
+	 *
+	 * @param \WC_Shipping_Rate $shipping_rate The WooCommerce shipping rate.
+	 * @param array             $config        Configuration array.
+	 */
 	public function __construct( $shipping_rate, $config = array() ) {
 		parent::__construct( $config );
 
@@ -58,38 +58,43 @@ class CartLineShipping extends OrderLineData {
 
 	/**
 	 * Abstract function to set product name
+	 *
 	 * @return void
 	 */
 	public function set_name() {
-        $this->name = apply_filters( $this->get_filter_name( 'name' ), $this->shipping_rate->get_label(), $this->shipping_rate );
+		$this->name = apply_filters( $this->get_filter_name( 'name' ), $this->shipping_rate->get_label(), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product sku
+	 *
 	 * @return void
 	 */
 	public function set_sku() {
-        $this->sku = apply_filters( $this->get_filter_name( 'sku' ), $this->shipping_rate->get_id(), $this->shipping_rate );
+		$this->sku = apply_filters( $this->get_filter_name( 'sku' ), $this->shipping_rate->get_id(), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product quantity
+	 *
 	 * @return void
 	 */
 	public function set_quantity() {
-        $this->quantity = apply_filters( $this->get_filter_name( 'quantity' ), 1, $this->shipping_rate );
+		$this->quantity = apply_filters( $this->get_filter_name( 'quantity' ), 1, $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product unit price
+	 *
 	 * @return void
 	 */
 	public function set_unit_price() {
-        $this->unit_price = apply_filters( $this->get_filter_name( 'unit_price' ), $this->format_price( $this->shipping_rate->get_cost() ), $this->shipping_rate );
+		$this->unit_price = apply_filters( $this->get_filter_name( 'unit_price' ), $this->format_price( $this->shipping_rate->get_cost() ), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product subtotal unit price
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_unit_price() {
@@ -98,34 +103,38 @@ class CartLineShipping extends OrderLineData {
 
 	/**
 	 * Abstract function to set product tax rate
+	 *
 	 * @return void
 	 */
 	public function set_tax_rate() {
-        $item_tax_rate = 0;
+		$item_tax_rate = 0;
 
 		// Get the first key from the tax rates array.
-		$taxes = $this->shipping_rate->get_taxes();
-
+		$taxes = $this->shipping_rate->get_taxes;
 		if ( ! empty( $taxes ) ) {
 			$tax_rate_id   = array_key_first( $taxes );
 			$_tax          = new \WC_Tax();
 			$vat           = $_tax->get_rate_percent_value( $tax_rate_id );
 			$item_tax_rate = round( $vat * 100 );
+		} else {
+			$item_tax_rate = 0.0 === floatval( $this->shipping_rate->get_cost() ) ? 0 : round( WC()->cart->get_shipping_tax() / $this->shipping_rate->get_cost() * 10000 );
 		}
 
-        $this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $item_tax_rate, $this->shipping_rate );
+		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $item_tax_rate, $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product total amount
+	 *
 	 * @return void
 	 */
 	public function set_total_amount() {
-        $this->total_amount = apply_filters( $this->get_filter_name( 'total_amount' ), $this->format_price( $this->shipping_rate->get_cost() ), $this->shipping_rate );
+		$this->total_amount = apply_filters( $this->get_filter_name( 'total_amount' ), $this->format_price( $this->shipping_rate->get_cost() ), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product subtotal amount
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_amount() {
@@ -134,65 +143,75 @@ class CartLineShipping extends OrderLineData {
 
 	/**
 	 * Abstract function to set product total discount amount
+	 *
 	 * @return void
 	 */
 	public function set_total_discount_amount() {
-        $this->total_discount_amount = apply_filters( $this->get_filter_name( 'discount_amount' ), 0, $this->shipping_rate );
-    }
+		$this->total_discount_amount = apply_filters( $this->get_filter_name( 'discount_amount' ), 0, $this->shipping_rate );
+	}
 
 	/**
-     * Abstract function to set product total discount tax amount
-     * @return void
-     */
-    public function set_total_discount_tax_amount() {
+	 * Abstract function to set product total discount tax amount
+	 *
+	 * @return void
+	 */
+	public function set_total_discount_tax_amount() {
 		$this->total_discount_tax_amount = apply_filters( $this->get_filter_name( 'total_discount_tax_amount' ), 0, $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product total tax amount
+	 *
 	 * @return void
 	 */
 	public function set_total_tax_amount() {
-        $this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $this->shipping_rate->get_shipping_tax() ), $this->shipping_rate );
+		$shipping_tax           = ( 0.0 === $this->shipping_rate->get_shipping_tax() ) ? WC()->cart->get_shipping_tax() : $this->shipping_rate->get_shipping_tax();
+		$this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $shipping_tax ), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product subtotal tax amount
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_tax_amount() {
-		$this->subtotal_tax_amount = apply_filters( $this->get_filter_name( 'subtotal_tax_amount' ), $this->format_price( $this->shipping_rate->get_shipping_tax() ), $this->shipping_rate );
+		$shipping_tax              = ( 0.0 === $this->shipping_rate->get_shipping_tax() ) ? WC()->cart->get_shipping_tax() : $this->shipping_rate->get_shipping_tax();
+		$this->subtotal_tax_amount = apply_filters( $this->get_filter_name( 'subtotal_tax_amount' ), $this->format_price( $shipping_tax ), $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product type
+	 *
 	 * @return void
 	 */
 	public function set_type() {
-        $this->type = apply_filters( $this->get_filter_name( 'type' ), 'shipping', $this->shipping_rate );
+		$this->type = apply_filters( $this->get_filter_name( 'type' ), 'shipping', $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product url
+	 *
 	 * @return void
 	 */
 	public function set_product_url() {
-        $this->product_url = apply_filters( $this->get_filter_name( 'product_url' ), null, $this->shipping_rate );
+		$this->product_url = apply_filters( $this->get_filter_name( 'product_url' ), null, $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product image url
+	 *
 	 * @return void
 	 */
 	public function set_image_url() {
-        $this->image_url = apply_filters( $this->get_filter_name( 'image_url' ), null, $this->shipping_rate );
+		$this->image_url = apply_filters( $this->get_filter_name( 'image_url' ), null, $this->shipping_rate );
 	}
 
 	/**
 	 * Abstract function to set product compatability
+	 *
 	 * @return void
 	 */
 	public function set_compatability() {
-        $this->compatability = apply_filters( $this->get_filter_name( 'compatability' ), array(), $this->shipping_rate );
+		$this->compatability = apply_filters( $this->get_filter_name( 'compatability' ), array(), $this->shipping_rate );
 	}
 }

--- a/src/Order/OrderLine.php
+++ b/src/Order/OrderLine.php
@@ -94,7 +94,7 @@ abstract class OrderLine extends OrderLineData {
 		$taxes    = $this->order_line_item->get_taxes();
 		if ( ! empty( $taxes['total'] ) ) {
 			foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-				if ( floatval( $tax_amount ) > 0.0 ) {
+				if ( abs( floatval( $tax_amount ) ) > 0.0 ) {
 					$tax_rate = \WC_Tax::get_rate_percent_value( $tax_id ) * 100;
 
 					// If the tax rate cannot be retrieved by using the tax id, use the tax amount to manually calculate the tax rate. NOTE: Avatax tax id cannot be retrieved from WC_Tax.

--- a/src/Order/OrderLine.php
+++ b/src/Order/OrderLine.php
@@ -22,7 +22,7 @@ abstract class OrderLine extends OrderLineData {
 	 * Constructor.
 	 *
 	 * @param \WC_Order_Item $order_line_item The order line item.
-	 * @param array $config Configuration array.
+	 * @param array          $config Configuration array.
 	 */
 	public function __construct( $order_line_item, $config = array() ) {
 		parent::__construct( $config );
@@ -50,6 +50,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product name
+	 *
 	 * @return void
 	 */
 	public function set_name() {
@@ -58,6 +59,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product quantity
+	 *
 	 * @return void
 	 */
 	public function set_quantity() {
@@ -66,6 +68,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product unit price
+	 *
 	 * @return void
 	 */
 	public function set_unit_price() {
@@ -83,6 +86,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product tax rate
+	 *
 	 * @return void
 	 */
 	public function set_tax_rate() {
@@ -90,8 +94,15 @@ abstract class OrderLine extends OrderLineData {
 		$taxes    = $this->order_line_item->get_taxes();
 		if ( ! empty( $taxes['total'] ) ) {
 			foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-				if ( ! empty( $tax_amount ) ) {
+				if ( floatval( $tax_amount ) > 0.0 ) {
 					$tax_rate = \WC_Tax::get_rate_percent_value( $tax_id ) * 100;
+
+					// If the tax rate cannot be retrieved by using the tax id, use the tax amount to manually calculate the tax rate. NOTE: Avatax tax id cannot be retrieved from WC_Tax.
+					if ( empty( $tax_rate ) ) {
+						$total_tax_amount = array_sum( array_values( $taxes['total'] ) ) * 100;
+						$tax_rate         = $this->order_line_item->get_total() === 0 ? 0 : $total_tax_amount / $this->order_line_item->get_total() * 100;
+					}
+
 					break;
 				}
 			}
@@ -102,6 +113,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product total amount
+	 *
 	 * @return void
 	 */
 	public function set_total_amount() {
@@ -119,6 +131,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product total tax amount
+	 *
 	 * @return void
 	 */
 	public function set_total_tax_amount() {
@@ -136,6 +149,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product url
+	 *
 	 * @return void
 	 */
 	public function set_product_url() {
@@ -144,6 +158,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product image url
+	 *
 	 * @return void
 	 */
 	public function set_image_url() {
@@ -152,6 +167,7 @@ abstract class OrderLine extends OrderLineData {
 
 	/**
 	 * Abstract function to set product compatability
+	 *
 	 * @return void
 	 */
 	public function set_compatability() {


### PR DESCRIPTION
~~**THIS IS STILL IN PROGRESS!!!**~~

~~Currently, I've managed to solve the issues related to retrieving the tax amount and rate while we're still working with the WC cart. However, what still remain is to figure out why the tax rate is zero, although the tax amount is greater than zero when placing the order. This seems to be related to `src/Order`. Once the issue has been identified and solved, we could directly import the changes to Klarna Order Management.~~

Avatax store the split tax in the `$this->cart_item['line_tax'] `. This should now as expected, and has been sent to merchant to verify that it works for them too.
