### PR TITLE
Version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+------------------
+
+## [1.2.0] - 2023-06-19
+
 ### Added
 * Added support standard Coupons.
 * Added support for handling Store Api carts.
 
 ### Fixed
 * Fixed and issue with how we handled YITH Giftcards.
-
-------------------
 
 ## [1.1.0] - 2023-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Changelog
 
-All notable changes of wp-api are documented in this file.
+All notable changes of krokedil/woocommerce are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+------------------
+
+## [1.2.1] - 2023-06-20
+
 ### Changes
 * We now use the first package returned when getting packages from the cart instead of the one with the key 0. This should improve compatibility with other plugins that might use something other then a incrementing integer for the package key. For example WooCommerce Advanced Shipping Packages, which uses the post id of the package as the key.
-
-------------------
 
 ## [1.2.0] - 2023-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+* We now use the first package returned when getting packages from the cart instead of the one with the key 0. This should improve compatibility with other plugins that might use something other then a incrementing integer for the package key. For example WooCommerce Advanced Shipping Packages, which uses the post id of the package as the key.
+
 ------------------
 
 ## [1.2.0] - 2023-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ------------------
 
+## [1.3.0] - 2023-10-03
+
+### Added
+* Added support for WooCommerce Subscriptions. We will no longer add shipping cost if the order is a free trial subscription without any shipping costs
+
+### Fixed
+* We will now default to empty strings in customer details if no value can be found from the checkout object.
+
 ## [1.2.1] - 2023-06-20
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To require this package, you need to require it in your composer.json file and a
 
 ### Usage
 
-The library currently contains helper classes to generate formated data from a WooCommerce cart, or a WooCommerce order.
+The library currently contains helper classes to generate formated data from a WooCommerce cart, a WooCommerce order or from a Store API Cart.
 
 To get started, its a good idea to setup a configuration array with the data with the configurations that you want to use when generating the data. The configuration will setup some things that will be used through the library, like what format to use for the price, and what slug to use as a prefix for all the filters used.
 

--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -78,7 +78,12 @@ class Cart extends OrderData {
 			}
 
 			$shipping_ids   = array_unique( $chosen_shipping_methods );
-			$shipping_rates = WC()->shipping->get_packages()[0]['rates'] ?? array();
+			// Only use the first package in the cart.
+			$packages = WC()->shipping->get_packages() ?? array();
+			$package  = reset( $packages );
+
+			// Get the shipping rates for the package.
+			$shipping_rates = $package['rates'] ?? array();
 			foreach ( $shipping_ids as $shipping_id ) {
 				if ( $shipping_rates[ $shipping_id ] ?? false ) {
 					$shipping_rate         = $shipping_rates[ $shipping_id ];


### PR DESCRIPTION
### Added
* Added support for WooCommerce Subscriptions. We will no longer add shipping cost if the order is a free trial subscription without any shipping costs

### Fixed
* We will now default to empty strings in customer details if no value can be found from the checkout object.