### PR TITLE
Add support for multiple taxes per order line item

### DIFF
--- a/src/Cart/CartLineItem.php
+++ b/src/Cart/CartLineItem.php
@@ -197,9 +197,7 @@ class CartLineItem extends OrderLineData {
 	 * @return void
 	 */
 	public function set_total_tax_amount() {
-		$taxes                  = count( $this->cart_item['line_tax_data']['total'] );
-		$total_tax_amount       = $taxes > 1 ? array_sum( $this->cart_item['line_tax_data']['total'] ) : $this->cart_item['line_tax'];
-		$this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $total_tax_amount ), $this->cart_item );
+		$this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $this->cart_item['line_tax'] ), $this->cart_item );
 	}
 
 	/**

--- a/src/Cart/CartLineItem.php
+++ b/src/Cart/CartLineItem.php
@@ -135,19 +135,20 @@ class CartLineItem extends OrderLineData {
 	public function set_tax_rate() {
 		$item_tax_rate = 0;
 		if ( $this->product->is_taxable() && $this->cart_item['line_subtotal_tax'] > 0 ) {
-			$tax           = new \WC_Tax();
-			$tax_rates     = $tax->get_rates( $this->product->get_tax_class() );
-			$item_tax_rate = array_sum(
-				array_map(
+			$tax       = new \WC_Tax();
+			$tax_rates = $tax->get_rates( $this->product->get_tax_class() );
+			if ( empty( $tax_rates ) ) {
+				$item_tax_rate = 0.0 === floatval( $this->cart_item['line_total'] ) ? 0 : round( $this->cart_item['line_tax'] / $this->cart_item['line_total'] * 10000 );
+			} else {
+				$item_tax_rate = array_map(
 					function ( $i ) {
-						return round( $i['rate'] * 100 ) ?? 0;
+						return round( ( $i['rate'] ?? 0 ) * 100 );
 					},
 					$tax_rates
-				)
-			);
-
-			$item_tax_rate = 0.0 === floatval( $this->cart_item['line_total'] ) ? 0 : round( $this->cart_item['line_tax'] / $this->cart_item['line_total'] * 10000 );
+				);
+			}
 		}
+
 		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $item_tax_rate, $this->cart_item );
 	}
 

--- a/src/Cart/CartLineItem.php
+++ b/src/Cart/CartLineItem.php
@@ -135,14 +135,18 @@ class CartLineItem extends OrderLineData {
 	public function set_tax_rate() {
 		$item_tax_rate = 0;
 		if ( $this->product->is_taxable() && $this->cart_item['line_subtotal_tax'] > 0 ) {
-			$_tax      = new \WC_Tax();
-			$tmp_rates = $_tax->get_rates( $this->product->get_tax_class() );
-			$vat       = array_shift( $tmp_rates );
-			if ( isset( $vat['rate'] ) ) {
-				$item_tax_rate = round( $vat['rate'] * 100 );
-			} else {
-				$item_tax_rate = 0.0 === floatval( $this->cart_item['line_total'] ) ? 0 : round( $this->cart_item['line_tax'] / $this->cart_item['line_total'] * 10000 );
-			}
+			$tax           = new \WC_Tax();
+			$tax_rates     = $tax->get_rates( $this->product->get_tax_class() );
+			$item_tax_rate = array_sum(
+				array_map(
+					function ( $i ) {
+						return round( $i['rate'] * 100 ) ?? 0;
+					},
+					$tax_rates
+				)
+			);
+
+			$item_tax_rate = 0.0 === floatval( $this->cart_item['line_total'] ) ? 0 : round( $this->cart_item['line_tax'] / $this->cart_item['line_total'] * 10000 );
 		}
 		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $item_tax_rate, $this->cart_item );
 	}
@@ -193,7 +197,9 @@ class CartLineItem extends OrderLineData {
 	 * @return void
 	 */
 	public function set_total_tax_amount() {
-		$this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $this->cart_item['line_tax'] ), $this->cart_item );
+		$taxes                  = count( $this->cart_item['line_tax_data']['total'] );
+		$total_tax_amount       = $taxes > 1 ? array_sum( $this->cart_item['line_tax_data']['total'] ) : $this->cart_item['line_tax'];
+		$this->total_tax_amount = apply_filters( $this->get_filter_name( 'total_tax_amount' ), $this->format_price( $total_tax_amount ), $this->cart_item );
 	}
 
 	/**

--- a/src/Cart/CartLineShipping.php
+++ b/src/Cart/CartLineShipping.php
@@ -112,10 +112,14 @@ class CartLineShipping extends OrderLineData {
 		// Get the first key from the tax rates array.
 		$taxes = $this->shipping_rate->get_taxes;
 		if ( ! empty( $taxes ) ) {
-			$tax_rate_id   = array_key_first( $taxes );
-			$_tax          = new \WC_Tax();
-			$vat           = $_tax->get_rate_percent_value( $tax_rate_id );
-			$item_tax_rate = round( $vat * 100 );
+			$tax      = new \WC_Tax();
+			$tax_rate = 0;
+
+			// There may be more than one tax rate applied. This is always the case when you have multiple tax rates defined under the same tax group with different priority.
+			foreach ( $taxes as $tax_id => $tax_amount ) {
+				$tax_rate += $tax->get_rate_percent_value( $tax_id );
+			}
+			$item_tax_rate = round( $tax_rate * 100 );
 		} else {
 			$item_tax_rate = 0.0 === floatval( $this->shipping_rate->get_cost() ) ? 0 : round( WC()->cart->get_shipping_tax() / $this->shipping_rate->get_cost() * 10000 );
 		}

--- a/src/Order/OrderLine.php
+++ b/src/Order/OrderLine.php
@@ -95,24 +95,23 @@ abstract class OrderLine extends OrderLineData {
 		if ( ! empty( $taxes['total'] ) ) {
 			foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
 				if ( abs( floatval( $tax_amount ) ) > 0.0 ) {
-					$tax_rate = \WC_Tax::get_rate_percent_value( $tax_id ) * 100;
+					$tax_rate += \WC_Tax::get_rate_percent_value( $tax_id ) * 100;
 
 					// If the tax rate cannot be retrieved by using the tax id, use the tax amount to manually calculate the tax rate. NOTE: Avatax tax id cannot be retrieved from WC_Tax.
 					if ( empty( $tax_rate ) ) {
 						$total_tax_amount = array_sum( array_values( $taxes['total'] ) ) * 100;
 						$tax_rate         = $this->order_line_item->get_total() === 0 ? 0 : $total_tax_amount / $this->order_line_item->get_total() * 100;
-					}
 
-					break;
+					}
 				}
 			}
-		}
 
-		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $tax_rate, $this->order_line_item );
+			$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), $tax_rate, $this->order_line_item );
+		}
 	}
 
 	/**
-	 * Abstract function to set product total amount
+	 * Abstract function to set product total amount.
 	 *
 	 * @return void
 	 */

--- a/src/OrderLineData.php
+++ b/src/OrderLineData.php
@@ -15,341 +15,396 @@ use Krokedil\WooCommerce\Base;
 abstract class OrderLineData extends Base {
 	/**
 	 * The name of the product or service.
+	 *
 	 * @var string
 	 */
 	public $name;
 
 	/**
 	 * The product's unique SKU code.
+	 *
 	 * @var string
 	 */
 	public $sku;
 
 	/**
 	 * The number of items ordered.
+	 *
 	 * @var int
 	 */
 	public $quantity;
 
 	/**
 	 * The price of a single unit of the item, excluding tax.
+	 *
 	 * @var float|int
 	 */
 	public $unit_price;
 
-    /**
-     * The price of a single unit of the item, excluding tax, before any discounts are applied.
-     * @var float|int
-     */
-    public $subtotal_unit_price;
+	/**
+	 * The price of a single unit of the item, excluding tax, before any discounts are applied.
+	 *
+	 * @var float|int
+	 */
+	public $subtotal_unit_price;
 
 	/**
 	 * The tax rate applied to the item.
-	 * @var float|int
+	 *
+	 * @var array<float|int>|float|int
 	 */
 	public $tax_rate;
 
 	/**
 	 * The total cost of the line, excluding tax.
+	 *
 	 * @var float|int
 	 */
 	public $total_amount;
 
-    /**
-     * The total cost of the line, excluding tax, before any discounts are applied.
-     * @var float|int
-     */
-    public $subtotal_amount;
+	/**
+	 * The total cost of the line, excluding tax, before any discounts are applied.
+	 *
+	 * @var float|int
+	 */
+	public $subtotal_amount;
 
 	/**
 	 * The total amount of discounts applied to the line.
+	 *
 	 * @var float|int
 	 */
 	public $total_discount_amount;
 
-    /**
-     * The total amount of discounted tax to the line.
-     *
-     * @var float|int
-     */
+	/**
+	 * The total amount of discounted tax to the line.
+	 *
+	 * @var float|int
+	 */
 	public $total_discount_tax_amount;
 
 	/**
 	 * The total amount of tax applied to the line.
+	 *
 	 * @var float|int
 	 */
 	public $total_tax_amount;
 
-    /**
-     * The total tax of the line, excluding tax, before any discounts are applied.
-     * @var float|int
-     */
-    public $subtotal_tax_amount;
+	/**
+	 * The total tax of the line, excluding tax, before any discounts are applied.
+	 *
+	 * @var float|int
+	 */
+	public $subtotal_tax_amount;
 
 	/**
 	 * The type of item.
+	 *
 	 * @var string
 	 */
 	public $type;
 
 	/**
 	 * The URL of the product or service.
+	 *
 	 * @var string
 	 */
 	public $product_url;
 
 	/**
 	 * The URL of an image of the product or service.
+	 *
 	 * @var string
 	 */
 	public $image_url;
 
 	/**
 	 * The part number or other unique identifier for the item.
+	 *
 	 * @var array
 	 */
 	public $compatability;
 
-    /**
-     * Abstract function to set product name
-     * @return void
-     */
-    public abstract function set_name();
+	/**
+	 * Abstract function to set product name
+	 *
+	 * @return void
+	 */
+	abstract public function set_name();
 
-    /**
-     * Abstract function to set product sku
-     * @return void
-     */
-    public abstract function set_sku();
+	/**
+	 * Abstract function to set product sku
+	 *
+	 * @return void
+	 */
+	abstract public function set_sku();
 
-    /**
-     * Abstract function to set product quantity
-     * @return void
-     */
-    public abstract function set_quantity();
+	/**
+	 * Abstract function to set product quantity
+	 *
+	 * @return void
+	 */
+	abstract public function set_quantity();
 
-    /**
-     * Abstract function to set product unit price
-     * @return void
-     */
-    public abstract function set_unit_price();
+	/**
+	 * Abstract function to set product unit price
+	 *
+	 * @return void
+	 */
+	abstract public function set_unit_price();
 
-    /**
-     * Abstract function to set product subtotal unit price. Unit price before any discounts are applied.
-     *
-     * @return void
-     */
-	public abstract function set_subtotal_unit_price();
+	/**
+	 * Abstract function to set product subtotal unit price. Unit price before any discounts are applied.
+	 *
+	 * @return void
+	 */
+	abstract public function set_subtotal_unit_price();
 
-    /**
-     * Abstract function to set product tax rate
-     * @return void
-     */
-    public abstract function set_tax_rate();
+	/**
+	 * Abstract function to set product tax rate
+	 *
+	 * @return void
+	 */
+	abstract public function set_tax_rate();
 
-    /**
-     * Abstract function to set product total amount
-     * @return void
-     */
-    public abstract function set_total_amount();
+	/**
+	 * Abstract function to set product total amount
+	 *
+	 * @return void
+	 */
+	abstract public function set_total_amount();
 
-    /**
-     * Abstract function to set product subtotal amount, total amount before any discounts are applied.
-     *
-     * @return void
-     */
-    public abstract function set_subtotal_amount();
+	/**
+	 * Abstract function to set product subtotal amount, total amount before any discounts are applied.
+	 *
+	 * @return void
+	 */
+	abstract public function set_subtotal_amount();
 
-    /**
-     * Abstract function to set product total discount amount
-     * @return void
-     */
-    public abstract function set_total_discount_amount();
+	/**
+	 * Abstract function to set product total discount amount
+	 *
+	 * @return void
+	 */
+	abstract public function set_total_discount_amount();
 
-    /**
-     * Abstract function to set product total discount tax amount
-     * @return void
-     */
-    public abstract function set_total_discount_tax_amount();
+	/**
+	 * Abstract function to set product total discount tax amount
+	 *
+	 * @return void
+	 */
+	abstract public function set_total_discount_tax_amount();
 
-    /**
-     * Abstract function to set product total tax amount
-     * @return void
-     */
-    public abstract function set_total_tax_amount();
+	/**
+	 * Abstract function to set product total tax amount
+	 *
+	 * @return void
+	 */
+	abstract public function set_total_tax_amount();
 
-    /**
-     * Abstract function to set product subtotal tax amount, total tax amount before any discounts are applied.
-     *
-     * @return void
-     */
-    public abstract function set_subtotal_tax_amount();
+	/**
+	 * Abstract function to set product subtotal tax amount, total tax amount before any discounts are applied.
+	 *
+	 * @return void
+	 */
+	abstract public function set_subtotal_tax_amount();
 
-    /**
-     * Abstract function to set product type
-     * @return void
-     */
-    public abstract function set_type();
+	/**
+	 * Abstract function to set product type
+	 *
+	 * @return void
+	 */
+	abstract public function set_type();
 
-    /**
-     * Abstract function to set product url
-     * @return void
-     */
-    public abstract function set_product_url();
+	/**
+	 * Abstract function to set product url
+	 *
+	 * @return void
+	 */
+	abstract public function set_product_url();
 
-    /**
-     * Abstract function to set product image url
-     * @return void
-     */
-    public abstract function set_image_url();
+	/**
+	 * Abstract function to set product image url
+	 *
+	 * @return void
+	 */
+	abstract public function set_image_url();
 
-    /**
-     * Abstract function to set product compatability
-     * @return void
-     */
-    public abstract function set_compatability();
+	/**
+	 * Abstract function to set product compatability
+	 *
+	 * @return void
+	 */
+	abstract public function set_compatability();
 
-    /**
-     * Function to get product name
-     * @return string
-     */
-    public function get_name() {
-        return $this->name;
-    }
+	/**
+	 * Function to get product name
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
+	}
 
-    /**
-     * Function to get product sku
-     * @return string
-     */
-    public function get_sku() {
-        return $this->sku;
-    }
+	/**
+	 * Function to get product sku
+	 *
+	 * @return string
+	 */
+	public function get_sku() {
+		return $this->sku;
+	}
 
-    /**
-     * Function to get product quantity
-     * @return int
-     */
-    public function get_quantity() {
-        return $this->quantity;
-    }
+	/**
+	 * Function to get product quantity
+	 *
+	 * @return int
+	 */
+	public function get_quantity() {
+		return $this->quantity;
+	}
 
-    /**
-     * Function to get product unit price
-     * @return float|int
-     */
-    public function get_unit_price() {
-        return $this->unit_price;
-    }
+	/**
+	 * Function to get product unit price
+	 *
+	 * @return float|int
+	 */
+	public function get_unit_price() {
+		return $this->unit_price;
+	}
 
-    /**
-     * Function to get product subtotal unit price
-     * @return float|int
-     */
-    public function get_subtotal_unit_price() {
-        return $this->subtotal_unit_price;
-    }
+	/**
+	 * Function to get product subtotal unit price
+	 *
+	 * @return float|int
+	 */
+	public function get_subtotal_unit_price() {
+		return $this->subtotal_unit_price;
+	}
 
 	/**
 	 * Function to get product unit tax amount
+	 *
 	 * @return float|int
 	 */
 	public function get_unit_tax_amount() {
 		return $this->total_tax_amount / $this->quantity;
 	}
 
-    /**
+	/**
 	 * Function to get product unit tax amount
+	 *
 	 * @return float|int
 	 */
 	public function get_subtotal_unit_tax_amount() {
 		return $this->subtotal_tax_amount / $this->quantity;
 	}
 
-    /**
-     * Function to get product tax rate
-     * @return float|int
-     */
-    public function get_tax_rate() {
-        return $this->tax_rate;
-    }
+	/**
+	 * Function to get product tax rate
+	 *
+	 * @param bool $single Whether the tax rate(s) should be summed as a single value or as separate array items.
+	 * @return float|int|array<float|int>
+	 */
+	public function get_tax_rate( $single = true ) {
+		if ( empty( $this->tax_rate ) ) {
+			return 0;
+		}
 
-    /**
-     * Function to get product total amount
-     * @return float|int
-     */
-    public function get_total_amount() {
-        return $this->total_amount;
-    }
+		if ( $single ) {
+			return is_array( $this->tax_rate ) ? array_sum( $this->tax_rate ) : $this->tax_rate;
+		}
 
-    /**
-     * Function to get product subtotal amount
-     * @return float|int
-     */
-    public function get_subtotal_amount() {
-        return $this->subtotal_amount;
-    }
+		return is_array( $this->tax_rate ) ? $this->tax_rate : array( $this->tax_rate );
+	}
 
-    /**
-     * Function to get product total discount amount
-     * @return float|int
-     */
-    public function get_total_discount_amount() {
-        return $this->total_discount_amount;
-    }
+	/**
+	 * Function to get product total amount
+	 *
+	 * @return float|int
+	 */
+	public function get_total_amount() {
+		return $this->total_amount;
+	}
 
-    /**
-     * Function to get product total discount tax amount
-     * @return float|int
-     */
-    public function get_total_discount_tax_amount() {
-        return $this->total_discount_tax_amount;
-    }
+	/**
+	 * Function to get product subtotal amount
+	 *
+	 * @return float|int
+	 */
+	public function get_subtotal_amount() {
+		return $this->subtotal_amount;
+	}
 
-    /**
-     * Function to get product total tax amount
-     * @return float|int
-     */
-    public function get_total_tax_amount() {
-        return $this->total_tax_amount;
-    }
+	/**
+	 * Function to get product total discount amount
+	 *
+	 * @return float|int
+	 */
+	public function get_total_discount_amount() {
+		return $this->total_discount_amount;
+	}
 
-    /**
-     * Function to get product subtotal tax amount
-     * @return float|int
-     */
-    public function get_subtotal_tax_amount() {
-        return $this->subtotal_tax_amount;
-    }
+	/**
+	 * Function to get product total discount tax amount
+	 *
+	 * @return float|int
+	 */
+	public function get_total_discount_tax_amount() {
+		return $this->total_discount_tax_amount;
+	}
 
-    /**
-     * Function to get product type
-     * @return string
-     */
-    public function get_type() {
-        return $this->type;
-    }
+	/**
+	 * Function to get product total tax amount
+	 *
+	 * @return float|int
+	 */
+	public function get_total_tax_amount() {
+		return $this->total_tax_amount;
+	}
 
-    /**
-     * Function to get product url
-     * @return string
-     */
-    public function get_product_url() {
-        return $this->product_url;
-    }
+	/**
+	 * Function to get product subtotal tax amount
+	 *
+	 * @return float|int
+	 */
+	public function get_subtotal_tax_amount() {
+		return $this->subtotal_tax_amount;
+	}
 
-    /**
-     * Function to get product image url
-     * @return string
-     */
-    public function get_image_url() {
-        return $this->image_url;
-    }
+	/**
+	 * Function to get product type
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+		return $this->type;
+	}
 
-    /**
-     * Function to get product compatability
-     * @return array
-     */
-    public function get_compatability() {
-        return $this->compatability;
-    }
+	/**
+	 * Function to get product url
+	 *
+	 * @return string
+	 */
+	public function get_product_url() {
+		return $this->product_url;
+	}
+
+	/**
+	 * Function to get product image url
+	 *
+	 * @return string
+	 */
+	public function get_image_url() {
+		return $this->image_url;
+	}
+
+	/**
+	 * Function to get product compatability
+	 *
+	 * @return array
+	 */
+	public function get_compatability() {
+		return $this->compatability;
+	}
 }


### PR DESCRIPTION
Currently, we only support one tax rate per order line. Once we found one, we abort. This also applies to shipping line. With this PR, we'll handle all the taxes instead.

Task: https://app.clickup.com/t/865d0fzd6