### PR TITLE
Retrieve discount type from WC_Coupon if coupon_data is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2024-03-12
+### Fixed
+* Fixed an issue that caused a critical error if the cart contained any coupon. This issue was introduced in WC v.8.7.0 where the metadata "coupon_data" has been removed.
 ------------------
 
 ## [1.4.0] - 2024-01-08

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -31,7 +31,7 @@ class Order extends OrderData {
 	 * Constructor.
 	 *
 	 * @param \WC_Order|\WC_Order_Refund $order The WooCommerce order.
-	 * @param array    $config Configuration array.
+	 * @param array                      $config Configuration array.
 	 */
 	public function __construct( $order, $config = array() ) {
 		parent::__construct( $config );
@@ -54,6 +54,7 @@ class Order extends OrderData {
 	}
 	/**
 	 * Sets the line items.
+	 *
 	 * @return void
 	 */
 	public function set_line_items() {
@@ -67,6 +68,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the shipping lines.
+	 *
 	 * @return void
 	 */
 	public function set_line_shipping() {
@@ -86,7 +88,7 @@ class Order extends OrderData {
 	public function set_line_coupons() {
 		// Smart coupons.
 		foreach ( $this->order->get_items( 'coupon' ) as $coupon ) {
-			$discount_type = $coupon->get_meta( 'coupon_data' )['discount_type'];
+			$discount_type = $coupon->meta_exists( 'coupon_data' ) ? $coupon->get_meta( 'coupon_data' )['discount_type'] : ( new \WC_Coupon( $coupon->get_name() ) )->get_discount_type();
 
 			if ( 'smart_coupon' === $discount_type || 'store_credit' === $discount_type ) {
 				$coupon_line = new OrderLineCoupon( $this->config );
@@ -139,6 +141,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the fee lines.
+	 *
 	 * @return void
 	 */
 	public function set_line_fees() {
@@ -152,6 +155,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the compatibility lines.
+	 *
 	 * @return void
 	 */
 	public function set_line_compatibility() {
@@ -160,6 +164,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the customer data.
+	 *
 	 * @return void
 	 */
 	public function set_customer() {
@@ -168,6 +173,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the total ex tax.
+	 *
 	 * @return void
 	 */
 	public function set_total() {
@@ -176,6 +182,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the total tax.
+	 *
 	 * @return void
 	 */
 	public function set_total_tax() {
@@ -184,6 +191,7 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the subtotal ex tax.
+	 *
 	 * @return void
 	 */
 	public function set_subtotal() {
@@ -192,10 +200,11 @@ class Order extends OrderData {
 
 	/**
 	 * Sets the subtotal tax.
+	 *
 	 * @return void
 	 */
 	public function set_subtotal_tax() {
 		// TODO - Subtotal tax
-		//$this->subtotal_tax = $this->format_price( $this->order->get_subtotal_tax() );
+		// $this->subtotal_tax = $this->format_price( $this->order->get_subtotal_tax() );
 	}
 }


### PR DESCRIPTION
It seems like WC introduced a change in v.8.7.0-beta.1 where the meta data "coupon_data" return an empty string. However, this change is not mentioned in the log, and has not been resolved as of v.8.7.0-rc.1.