### PR TITLE
Add abstract metabox class for standardized HPOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Added a abstract class for handling order metaboxes to simplify and standardize the process of adding metaboxes to the order edit screen after WooCommerce added HPOS.
 
 ------------------
 ## [1.6.1] - 2024-05-13

--- a/assets/css/metabox.css
+++ b/assets/css/metabox.css
@@ -1,0 +1,52 @@
+.krokedil_wc__metabox h4 {
+    margin-bottom: .1em;
+}
+
+.krokedil_wc__metabox_section {
+    margin-top: 2em;
+}
+
+h4.krokedil_wc__metabox_label {
+    cursor: pointer;
+    display: flex;
+    gap: 1em;
+    margin: 0;
+}
+
+.krokedil_wc__metabox_section_content {
+    display: flex;
+    flex-direction: column;
+}
+
+.krokedil_wc__metabox_label .dashicons {
+    transition: transform 0.15s ease;
+}
+
+.krokedil_wc__metabox_label .dashicons.krokedil_wc__metabox_open {
+    transform: rotate(-180deg);
+}
+
+.krokedil_wc__metabox_section {
+    padding-top: 1em;
+    border-top: 1px solid #e5e5e5;
+}
+
+div.krokedil_wc__metabox div.krokedil_wc__metabox_button,
+div.krokedil_wc__metabox a.krokedil_wc__metabox_action {
+    margin-top: 1em;
+}
+
+.krokedil_wc__metabox_toggle_wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1em;
+}
+
+.krokedil_wc__metabox_toggle_wrapper h4 {
+    margin-top: 0;
+}
+
+.krokedil_wc__metabox_toggle_wrapper .woocommerce-input-toggle {
+    cursor: pointer;
+}

--- a/assets/js/metabox.js
+++ b/assets/js/metabox.js
@@ -1,0 +1,26 @@
+jQuery(function ($) {
+  const krokedil_metabox = {
+    init: function () {
+      $(document).on(
+        "click",
+        ".krokedil_wc__metabox_section_toggle",
+        this.toggle
+      );
+    },
+
+    toggle: function (e) {
+      e.preventDefault();
+      const $this = $(this);
+      const $section = $this.closest(".krokedil_wc__metabox_section");
+      const $content = $section.find(".krokedil_wc__metabox_section_content");
+
+      $content.stop().slideToggle({
+        duration: 150,
+        easing: "linear",
+      });
+      $this.find(".dashicons").toggleClass("krokedil_wc__metabox_open");
+    },
+  };
+
+  krokedil_metabox.init();
+});

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,7 +14,7 @@
     <config name="testVersion" value="7.3-" />
 
     <!-- Use Wordpress Coding standards -->
-    <rule ref="Wordpress" />
+    <rule ref="WordPress" />
 
     <!-- Enforce the correct text-domain -->
     <rule ref="WordPress.WP.I18n">

--- a/src/Interfaces/MetaboxInterface.php
+++ b/src/Interfaces/MetaboxInterface.php
@@ -1,0 +1,31 @@
+<?php
+namespace Krokedil\WooCommerce\Interfaces;
+
+defined( 'ABSPATH' ) || exit;
+
+interface MetaboxInterface {
+	/**
+	 * Add metabox to order edit screen.
+	 *
+	 * @param string $post_type The post type for the current screen.
+	 *
+	 * @return void
+	 */
+	public function add_metabox( $post_type );
+
+	/**
+	 * Render the metabox.
+	 *
+	 * @param \WP_Post|\WC_Order $post The post object.
+	 *
+	 * @return void
+	 */
+	public function render_metabox( $post );
+
+	/**
+	 * Get the ID for the current screen.
+	 *
+	 * @return int
+	 */
+	public function get_id();
+}

--- a/src/OrderMetabox.php
+++ b/src/OrderMetabox.php
@@ -1,10 +1,9 @@
 <?php
 namespace Krokedil\WooCommerce;
 
-use Krokedil\WooCommerce\Interfaces\MetaboxInterface;
-
 defined( 'ABSPATH' ) || exit;
 
+use Krokedil\WooCommerce\Interfaces\MetaboxInterface;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 /**
@@ -35,6 +34,20 @@ abstract class OrderMetabox implements MetaboxInterface {
 	protected $payment_method_id;
 
 	/**
+	 * Script handles to enqueue.
+	 *
+	 * @var array
+	 */
+	protected $scripts = array();
+
+	/**
+	 * Style handles to enqueue.
+	 *
+	 * @var array
+	 */
+	protected $styles = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $id Metabox id.
@@ -49,6 +62,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 		$this->payment_method_id = $payment_method_id;
 
 		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
+		add_action( 'admin_init', array( $this, 'register_assets' ) );
 	}
 
 	/**
@@ -58,7 +72,22 @@ abstract class OrderMetabox implements MetaboxInterface {
 	 *
 	 * @return void
 	 */
-	abstract public function render_metabox( $post );
+	public function render_metabox( $post ) {
+		?>
+		<div class="krokedil_wc__metabox">
+			<?php $this->metabox_content( $post ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Output the metabox content.
+	 *
+	 * @param \WP_Post|\WC_Order $post The post object or a WC Order for later versions of WooCommerce.
+	 *
+	 * @return void
+	 */
+	abstract public function metabox_content( $post );
 
 	/**
 	 * Add metabox to order edit screen.
@@ -85,6 +114,8 @@ abstract class OrderMetabox implements MetaboxInterface {
 			return;
 		}
 
+		$this->enqueue_assets();
+
 		add_meta_box(
 			$this->id,
 			$this->title,
@@ -93,6 +124,49 @@ abstract class OrderMetabox implements MetaboxInterface {
 			'side',
 			'core'
 		);
+	}
+
+	/**
+	 * Enqueue the metabox assets.
+	 *
+	 * @return void
+	 */
+	protected function enqueue_assets() {
+		// Enqueue the default.
+		wp_enqueue_style( 'krokedil_wc_metabox' );
+		wp_enqueue_script( 'krokedil_wc_metabox' );
+
+		// Enqueue any custom scripts.
+		foreach ( $this->scripts as $script ) {
+			$this->maybe_localize_script( $script );
+			wp_enqueue_script( $script );
+		}
+
+		// Enqueue any custom styles.
+		foreach ( $this->styles as $style ) {
+			wp_enqueue_style( $style );
+		}
+	}
+
+	/**
+	 * Maybe localize the script with data.
+	 *
+	 * @param string $handle The script handle.
+	 *
+	 * @return void
+	 */
+	protected function maybe_localize_script( $handle ) {
+		// No default implementation.
+	}
+
+	/**
+	 * Register the metabox assets.
+	 *
+	 * @return void
+	 */
+	public function register_assets() {
+		wp_register_style( 'krokedil_wc_metabox', self::get_asset_url( 'css/metabox.css' ), array(), '1.0.0' );
+		wp_register_script( 'krokedil_wc_metabox', self::get_asset_url( 'js/metabox.js' ), array( 'jquery' ), '1.0.0', true );
 	}
 
 	/**
@@ -129,6 +203,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 	public function get_id() {
 		$hpos_enabled = $this->is_hpos_enabled();
 		$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+
 		if ( empty( $order_id ) ) {
 			return false;
 		}
@@ -145,7 +220,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 	 */
 	protected static function output_error( $message ) {
 		?>
-		<p class="krokedil_metabox krokedil_metabox__error">
+		<p class="krokedil_wc__metabox krokedil_metabox__error">
 			<?php echo esc_html( $message ); ?>
 		</p>
 		<?php
@@ -156,15 +231,19 @@ abstract class OrderMetabox implements MetaboxInterface {
 	 *
 	 * @param string $label Label for the text.
 	 * @param string $text Text to output.
+	 * @param string $tip Tip to show.
 	 *
 	 * @return void
 	 */
-	protected static function output_info( $label, $text ) {
+	protected static function output_info( $label, $text, $tip = null ) {
 		?>
-		<p class="krokedil_metabox">
-			<strong><?php echo esc_html( $label ); ?>:</strong>
-			<span><?php echo wp_kses_post( $text ); ?></span>
-		</p>
+		<h4>
+			<?php echo esc_html( $label ); ?>
+			<?php if ( $tip ) : ?>
+				<?php echo wp_kses_post( wc_help_tip( $tip ) ); ?>
+			<?php endif; ?>
+		</h4>
+		<span><?php echo wp_kses_post( $text ); ?></span>
 		<?php
 	}
 
@@ -183,7 +262,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 		$classes = trim( "button $classes" );
 
 		?>
-		<a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $classes ); ?>" <?php echo esc_url( $target ); ?>>
+		<a href="<?php echo esc_url( $url ); ?>" class="krokedil_wc__metabox_button krokedil_wc__metabox_action <?php echo esc_attr( $classes ); ?>" <?php echo esc_url( $target ); ?>>
 			<?php echo esc_html( $text ); ?>
 		</a>
 		<?php
@@ -203,13 +282,90 @@ abstract class OrderMetabox implements MetaboxInterface {
 
 		$data_attributes = '';
 		foreach ( $data as $key => $value ) {
-			$data_attributes .= " data-$key=\"$value\"";
+			$data_attributes .= " data-$key=$value";
 		}
 
 		?>
-		<button type="button" class="<?php echo esc_attr( $classes ); ?>"<?php echo esc_attr( $data_attributes ); ?>>
+		<button
+			type="button"
+			class="krokedil_wc__metabox_button <?php echo esc_attr( $classes ); ?>"
+			<?php echo esc_attr( $data_attributes ); ?>
+		>
 			<?php echo esc_html( $text ); ?>
 		</button>
 		<?php
+	}
+
+	/**
+	 * Output a toggle switch.
+	 *
+	 * @param string $label The label for the input.
+	 * @param bool   $checked Whether the switch should be checked.
+	 * @param string $tip The tip to show.
+	 * @param string $classes The classes to add to the input.
+	 * @param array  $data The data attributes to add to the input.
+	 */
+	protected static function output_toggle_switch( $label, $checked = false, $tip = null, $classes = '', $data = array() ) {
+		$data_attributes = '';
+		foreach ( $data as $key => $value ) {
+			$data_attributes .= " data-$key=$value";
+		}
+
+		$toggle_suffix = $checked ? 'enabled' : 'disabled';
+		$toggle_class  = "woocommerce-input-toggle--{$toggle_suffix}";
+
+		?>
+		<div class="krokedil_wc__metabox_toggle_wrapper">
+			<h4>
+				<?php echo esc_html( $label ); ?>
+				<?php if ( $tip ) : ?>
+					<?php echo wp_kses_post( wc_help_tip( $tip ) ); ?>
+				<?php endif; ?>
+			</h4>
+			<span
+				class="woocommerce-input-toggle <?php echo esc_attr( $toggle_class ); ?> <?php echo esc_attr( $classes ); ?>"
+				<?php echo esc_attr( $data_attributes ); ?>
+			></span>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Output a collapsable advanced section.
+	 *
+	 * @param string          $id The id for the section.
+	 * @param string          $label The label for the section.
+	 * @param string|callable $content The content to display in the section.
+	 * @param bool            $is_open Whether the section should be open by default.
+	 *
+	 * @return void
+	 */
+	protected static function output_collapsable_section( $id, $label, $content, $is_open = false ) {
+		?>
+		<div class="krokedil_wc__metabox_section">
+			<h4 class="krokedil_wc__metabox_label krokedil_wc__metabox_section_toggle">
+				<?php echo esc_html( $label ); ?>
+				<span class="dashicons dashicons-arrow-down <?php echo esc_attr( $is_open ? 'krokedil_wc__metabox_open' : '' ); ?>"></span>
+			</h4>
+			<div id="<?php echo esc_attr( $id ); ?>" class="krokedil_wc__metabox_section_content" style="<?php echo esc_attr( $is_open ? '' : 'display:none;' ); ?>">
+				<?php if ( is_callable( $content ) ) : ?>
+					<?php call_user_func( $content ); ?>
+				<?php else : ?>
+					<?php echo wp_kses_post( $content ); ?>
+				<?php endif; ?>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Get the url for assets in the package relative to the plugin root.
+	 *
+	 * @param string $path The path to the asset.
+	 *
+	 * @return string
+	 */
+	protected static function get_asset_url( $path ) {
+		return plugin_dir_url( __FILE__ ) . '../assets/' . rtrim( $path, '/' );
 	}
 }

--- a/src/OrderMetabox.php
+++ b/src/OrderMetabox.php
@@ -167,4 +167,49 @@ abstract class OrderMetabox implements MetaboxInterface {
 		</p>
 		<?php
 	}
+
+	/**
+	 * Output an action button.
+	 *
+	 * @param string $text The text to display on the button.
+	 * @param string $url The URL to link to.
+	 * @param bool   $new_tab Whether to open the link in a new tab.
+	 * @param string $classes The class to add to the button.
+	 *
+	 * @return void
+	 */
+	protected static function output_action_button( $text, $url, $new_tab = false, $classes = '' ) {
+		$target  = $new_tab ? 'target="_blank"' : '';
+		$classes = trim( "button $classes" );
+
+		?>
+		<a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $classes ); ?>" <?php echo esc_url( $target ); ?>>
+			<?php echo esc_html( $text ); ?>
+		</a>
+		<?php
+	}
+
+	/**
+	 * Output a button.
+	 *
+	 * @param string $text The text to display on the button.
+	 * @param string $classes The class to add to the button.
+	 * @param array  $data The data attributes to add to the button.
+	 *
+	 * @return void
+	 */
+	protected static function output_button( $text, $classes = '', $data = array() ) {
+		$classes = trim( "button $classes" );
+
+		$data_attributes = '';
+		foreach ( $data as $key => $value ) {
+			$data_attributes .= " data-$key=\"$value\"";
+		}
+
+		?>
+		<button type="button" class="<?php echo esc_attr( $classes ); ?>"<?php echo esc_attr( $data_attributes ); ?>>
+			<?php echo esc_html( $text ); ?>
+		</button>
+		<?php
+	}
 }

--- a/src/OrderMetabox.php
+++ b/src/OrderMetabox.php
@@ -1,0 +1,170 @@
+<?php
+namespace Krokedil\WooCommerce;
+
+use Krokedil\WooCommerce\Interfaces\MetaboxInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
+/**
+ * Class to handle metabox functionality for WooCommerce order pages.
+ *
+ * @package Krokedil\WooCommerce
+ */
+abstract class OrderMetabox implements MetaboxInterface {
+	/**
+	 * Metabox id.
+	 *
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * Metabox title.
+	 *
+	 * @var string
+	 */
+	protected $title;
+
+	/**
+	 * Payment method ID.
+	 *
+	 * @var string
+	 */
+	protected $payment_method_id;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $id Metabox id.
+	 * @param string $title Metabox title.
+	 * @param string $payment_method_id Payment method ID.
+	 *
+	 * @return void
+	 */
+	public function __construct( $id, $title, $payment_method_id ) {
+		$this->id                = $id;
+		$this->title             = $title;
+		$this->payment_method_id = $payment_method_id;
+
+		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
+	}
+
+	/**
+	 * Render the metabox.
+	 *
+	 * @param \WP_Post|\WC_Order $post The post object or a WC Order for later versions of WooCommerce.
+	 *
+	 * @return void
+	 */
+	abstract public function render_metabox( $post );
+
+	/**
+	 * Add metabox to order edit screen.
+	 *
+	 * @param string $post_type The post type for the current screen.
+	 *
+	 * @return void
+	 */
+	public function add_metabox( $post_type ) {
+		if ( ! $this->is_edit_order_screen( $post_type ) ) {
+			return;
+		}
+
+		// Ensure we are on a order page.
+		$order_id = $this->get_id();
+		$order    = $order_id ? wc_get_order( $order_id ) : false;
+		if ( ! $order_id || ! $order ) {
+			return;
+		}
+
+		// Ensure the order has the correct payment method id.
+		$payment_method = $order->get_payment_method();
+		if ( ! empty( $this->payment_method_id ) && $this->payment_method_id !== $payment_method ) {
+			return;
+		}
+
+		add_meta_box(
+			$this->id,
+			$this->title,
+			array( $this, 'render_metabox' ),
+			$post_type,
+			'side',
+			'core'
+		);
+	}
+
+	/**
+	 * Is HPOS enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_hpos_enabled() {
+		if ( class_exists( CustomOrdersTableController::class ) ) {
+			return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the current screen is the edit order screen.
+	 *
+	 * @param string $post_type The post type to check.
+	 *
+	 * @return bool
+	 */
+	public function is_edit_order_screen( $post_type ) {
+		$valid_screens = array( 'shop_order', 'woocommerce_page_wc-orders' );
+
+		return in_array( $post_type, $valid_screens, true );
+	}
+
+	/**
+	 * Get the order ID from the current screen.
+	 *
+	 * @return int|null
+	 */
+	public function get_id() {
+		$hpos_enabled = $this->is_hpos_enabled();
+		$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+		if ( empty( $order_id ) ) {
+			return false;
+		}
+
+		return $order_id;
+	}
+
+	/**
+	 * Print a error message into the metabox.
+	 *
+	 * @param string $message Error message to output.
+	 *
+	 * @return void
+	 */
+	private static function output_error( $message ) {
+		?>
+		<p class="krokedil_metabox krokedil_metabox__error">
+			<?php echo esc_html( $message ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Output labeled text info for the metabox.
+	 *
+	 * @param string $label Label for the text.
+	 * @param string $text Text to output.
+	 *
+	 * @return void
+	 */
+	private static function output_info( $label, $text ) {
+		?>
+		<p class="krokedil_metabox">
+			<strong><?php echo esc_html( $label ); ?>:</strong>
+			<span><?php echo wp_kses_post( $text ); ?></span>
+		</p>
+		<?php
+	}
+}

--- a/src/OrderMetabox.php
+++ b/src/OrderMetabox.php
@@ -143,7 +143,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 	 *
 	 * @return void
 	 */
-	private static function output_error( $message ) {
+	protected static function output_error( $message ) {
 		?>
 		<p class="krokedil_metabox krokedil_metabox__error">
 			<?php echo esc_html( $message ); ?>
@@ -159,7 +159,7 @@ abstract class OrderMetabox implements MetaboxInterface {
 	 *
 	 * @return void
 	 */
-	private static function output_info( $label, $text ) {
+	protected static function output_info( $label, $text ) {
 		?>
 		<p class="krokedil_metabox">
 			<strong><?php echo esc_html( $label ); ?>:</strong>


### PR DESCRIPTION
### Added
* Added a abstract class for handling order metaboxes to simplify and standardize the process of adding metaboxes to the order edit screen after WooCommerce added HPOS.