### PR TITLE
get_total return string whereas float is expected

### DIFF
--- a/src/Order/OrderLine.php
+++ b/src/Order/OrderLine.php
@@ -99,9 +99,9 @@ abstract class OrderLine extends OrderLineData {
 
 					// If the tax rate cannot be retrieved by using the tax id, use the tax amount to manually calculate the tax rate. NOTE: Avatax tax id cannot be retrieved from WC_Tax.
 					if ( empty( $tax_rate ) ) {
+						$total            = floatval( $this->order_line_item->get_total() );
 						$total_tax_amount = array_sum( array_values( $taxes['total'] ) ) * 100;
-						$tax_rate         = $this->order_line_item->get_total() === 0 ? 0 : $total_tax_amount / $this->order_line_item->get_total() * 100;
-
+						$tax_rate         = 0.0 === $total ? 0 : ( $total_tax_amount / $total ) * 100;
 					}
 				}
 			}


### PR DESCRIPTION
Since we use strict comparison, if `get_total` returns `"0"` (or `"0.0"`), the comparison will be false, resulting in the second expression being executed, thus dividing by zero.

As a matter of fact, the check will _always_ fail since we compare a numeric value to a string.

https://app.clickup.com/t/86958ayzb