### PR TITLE
1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ------------------
+## [1.6.2] - 2024-08-28
+### Fixed
+* Fixed a critical error when retrieving PW gift card from a Woo order.
+* Fixed a division by zero when calculating the tax rate.
+* Fixed an undefined index warning by ensuring that PW gift card exists before attempting retrieval.
+
 ## [1.6.1] - 2024-05-13
 ### Fixed
 * Reference to undefined method causes a fatal error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ------------------
+## [1.6.1] - 2024-05-13
+### Fixed
+* Reference to undefined method causes a fatal error.
+
 ## [1.6.0] - 2024-05-13
 ### Added
 * Added support for "Gift Cards" by Woo.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "krokedil/woocommerce",
     "description": "A library package for Krokedils plugins that contains helper methods when working with WooCommerce.",
     "type": "library",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "require-dev": {
         "php": "~7.1 || ~8.0",
         "php-stubs/wordpress-stubs": "^6.1",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "krokedil/woocommerce",
     "description": "A library package for Krokedils plugins that contains helper methods when working with WooCommerce.",
     "type": "library",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "require-dev": {
         "php": "~7.1 || ~8.0",
         "php-stubs/wordpress-stubs": "^6.1",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,7 +14,7 @@
     <config name="testVersion" value="7.3-" />
 
     <!-- Use Wordpress Coding standards -->
-    <rule ref="Wordpress" />
+    <rule ref="WordPress" />
 
     <!-- Enforce the correct text-domain -->
     <rule ref="WordPress.WP.I18n">

--- a/src/Cart/CartLineCoupon.php
+++ b/src/Cart/CartLineCoupon.php
@@ -20,7 +20,7 @@ class CartLineCoupon extends OrderLineData {
 	/**
 	 * WooCommerce Coupon data.
 	 *
-	 * @var WC_Coupon
+	 * @var \WC_Coupon
 	 */
 	public $coupon;
 
@@ -250,7 +250,6 @@ class CartLineCoupon extends OrderLineData {
 	 * @return self
 	 */
 	public function set_tax_rate( $tax_rate = null ) {
-		$tax_rate       = $tax_rate ?? $this->coupon->get_discount_tax_rate();
 		$this->tax_rate = apply_filters( $this->get_filter_name( 'tax_rate' ), 0, $this->coupon );
 
 		return $this;

--- a/src/Compatibility/Giftcards/PWGiftCards.php
+++ b/src/Compatibility/Giftcards/PWGiftCards.php
@@ -14,9 +14,13 @@ class PWGiftCards extends AbstractGiftCardCompatibility {
 	 * @return OrderLineData[]
 	 */
 	public function get_cart_giftcards() {
-		$coupons = array();
+		$coupons           = array();
+		$pw_gift_card_data = WC()->session->get( 'pw-gift-card-data', array() );
 
-		$pw_gift_card_data = WC()->session->get( 'pw-gift-card-data' );
+		if ( ! isset( $pw_gift_card_data['gift_cards'] ) ) {
+			return $coupons;
+		}
+
 		foreach ( $pw_gift_card_data['gift_cards'] as $code => $value ) {
 			$amount    = $value * -1;
 			$coupons[] = $this->create_gift_card( "$this->name $code", $this->sku, $this->type, $amount );


### PR DESCRIPTION
### Fixed
* Fixed a critical error when retrieving PW gift card from a Woo order.
* Fixed a division by zero when calculating the tax rate.
* Fixed an undefined index warning by ensuring that PW gift card exists before attempting retrieval.