### PR TITLE
Fix bug if admin user creates an order and deletes the price from the shipping method making it string '' instead of string '0'

### DIFF
--- a/src/Order/OrderLine.php
+++ b/src/Order/OrderLine.php
@@ -72,7 +72,7 @@ abstract class OrderLine extends OrderLineData {
 	 * @return void
 	 */
 	public function set_unit_price() {
-		$this->unit_price = apply_filters( $this->get_filter_name( 'unit_price' ), $this->format_price( $this->order_line_item->get_total() / $this->order_line_item->get_quantity() ), $this->order_line_item );
+		$this->unit_price = apply_filters( $this->get_filter_name( 'unit_price' ), $this->format_price( (float) $this->order_line_item->get_total() / $this->order_line_item->get_quantity() ), $this->order_line_item );
 	}
 
 	/**
@@ -81,7 +81,7 @@ abstract class OrderLine extends OrderLineData {
 	 * @return void
 	 */
 	public function set_subtotal_unit_price() {
-		$this->subtotal_unit_price = apply_filters( $this->get_filter_name( 'subtotal_unit_price' ), $this->format_price( $this->order_line_item->get_total() / $this->order_line_item->get_quantity() ), $this->order_line_item );
+		$this->subtotal_unit_price = apply_filters( $this->get_filter_name( 'subtotal_unit_price' ), $this->format_price( (float) $this->order_line_item->get_total() / $this->order_line_item->get_quantity() ), $this->order_line_item );
 	}
 
 	/**


### PR DESCRIPTION
Our client encountered some 500 errors relating to pay-for-order links relating to one specific order. On investigation we found the value of $this->order_line_item->get_total() was returning an empty string. The admin user had created the order added a shipping line and deleted the shipping price to make it effectively free instead of leaving it as '0'.

This caused `PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string / int`

`Stack trace:
#0 /wp-content/plugins/klarna-payments-for-woocommerce/dependencies/krokedil/woocommerce/src/Order/OrderLine.php(33): KrokedilKlarnaPaymentsDeps\Krokedil\WooCommerce\Order\OrderLine->set_unit_price()
#1 /wp-content/plugins/klarna-payments-for-woocommerce/dependencies/krokedil/woocommerce/src/Order/OrderLineShipping.php(27): KrokedilKlarnaPaymentsDeps\Krokedil\WooCommerce\Order\OrderLine->__construct()
#2 /wp-content/plugins/klarna-payments-for-woocommerce/dependencies/krokedil/woocommerce/src/Order/Order.php(72): KrokedilKlarnaPaymentsDeps\Krokedil\WooCommerce\Order\OrderLineShipping->__construct()
#3 /wp-content/plugins/klarna-payments-for-woocommerce/dependencies/krokedil/woocommer" while reading response header from upstream, client: 172.70.163.175, request: "GET /checkout/order-pay/277767/?pay_for_order=true HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.2-fpm.sock:"`

Casting the value to a float resolves any issues around this as both '0' and '' will cast to 0.00