### PR TITLE
Return the SKU as a string

### DIFF
--- a/src/OrderLineData.php
+++ b/src/OrderLineData.php
@@ -252,7 +252,7 @@ abstract class OrderLineData extends Base {
 	 * @return string
 	 */
 	public function get_sku() {
-		return $this->sku;
+		return strval( $this->sku );
 	}
 
 	/**


### PR DESCRIPTION
If the SKU is not set, we'll default to the product ID, which is an integer whereas a string is expected.

https://app.clickup.com/t/8696hv7ff