### PR TITLE
Checks whether a cart item is a subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added Subscription class to handle subscription specific logic. Use the 'is_subscription_item' method to check if an cart item is a subscription. This method is compatible with the plugins "WooCommerce Subscriptions" and "WooCommerce All Products for Subscriptions" by WooCommerce.
+
 ------------------
 ## [1.8.1] - 2025-06-03
 ### Added

--- a/src/OrderUtility.php
+++ b/src/OrderUtility.php
@@ -44,23 +44,4 @@ class OrderUtility {
 
 		return $order;
 	}
-
-	/**
-	 * Check if a cart item is a subscription item.
-	 *
-	 * @param array $cart_item The cart item to check.
-	 *
-	 * @return bool True if the cart item is a subscription item, false otherwise.
-	 */
-	public static function is_subscription_item( $cart_item ) {
-		if ( class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
-			return true;
-		}
-
-		if ( method_exists( 'WCS_ATT_Cart', 'get_subscription_scheme' ) && false !== \WCS_ATT_Cart::get_subscription_scheme( $cart_item ) ) {
-			return true;
-		}
-
-		return false;
-	}
 }

--- a/src/OrderUtility.php
+++ b/src/OrderUtility.php
@@ -44,4 +44,23 @@ class OrderUtility {
 
 		return $order;
 	}
+
+	/**
+	 * Check if a cart item is a subscription item.
+	 *
+	 * @param array $cart_item The cart item to check.
+	 *
+	 * @return bool True if the cart item is a subscription item, false otherwise.
+	 */
+	public static function is_subscription_item( $cart_item ) {
+		if ( class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
+			return true;
+		}
+
+		if ( method_exists( 'WCS_ATT_Cart', 'get_subscription_scheme' ) && false !== \WCS_ATT_Cart::get_subscription_scheme( $cart_item ) ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1,0 +1,31 @@
+<?php
+namespace Krokedil\WooCommerce;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Utility functions for Subscriptions.
+ *
+ * @package Krokedil/WooCommerce
+ */
+class Subscription {
+
+	/**
+	 * Check if a cart item is a subscription item.
+	 *
+	 * @param array $cart_item The cart item to check.
+	 *
+	 * @return bool True if the cart item is a subscription item, false otherwise.
+	 */
+	public static function is_subscription_item( $cart_item ) {
+		if ( class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
+			return true;
+		}
+
+		if ( method_exists( 'WCS_ATT_Cart', 'get_subscription_scheme' ) && false !== \WCS_ATT_Cart::get_subscription_scheme( $cart_item ) ) {
+			return true;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
Checks whether a cart item is a subscription. This is compatible with the plugins "WooCommerce Subscriptions" and "WooCommerce All Products for Subscriptions" by WooCommerce.

https://app.clickup.com/t/869a8pd0v