### PR TITLE
Make sure checkout is available in CartCustomer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Improved error handling in `CartCustomer` by checking the availability of the checkout object before accessing it, preventing potential errors when the checkout is unavailable.
+
 ------------------
 ## [1.9.0] - 2025-08-29
 ### Added

--- a/src/Cart/CartCustomer.php
+++ b/src/Cart/CartCustomer.php
@@ -28,6 +28,11 @@ class CartCustomer extends CustomerData {
 	public function __construct( $config = array() ) {
 		parent::__construct( $config );
 
+		// Make sure checkout is available.
+		if ( ! WC()->checkout ) {
+			return;
+		}
+
 		$this->set_billing_first_name();
 		$this->set_billing_last_name();
 		$this->set_billing_company();


### PR DESCRIPTION
Not sure if an error should be thrown here instead. Needs to be combined with [this PR for KP](https://github.com/krokedil/klarna-payments-for-woocommerce/pull/515), to avoid PHP warnings.